### PR TITLE
change compute_gradient() so it doesn't allocate a new gradient struct every call

### DIFF
--- a/ml.c
+++ b/ml.c
@@ -37,9 +37,10 @@ double cost(size_t n, size_t m, double *x, double *w, double b, double *y)
         return (1.0/(2.0 * m)) * cost; 
 }
 
-struct Gradient *compute_gradient(size_t n, size_t m, double *x, double *y, double *w, double b)
+struct Gradient *compute_gradient(size_t n, size_t m, double *x, double *y, double *w, double b, Gradient *gradient)
 {
-        struct Gradient *gradient = alloc_gradient(n);
+	if (gradient->n != n)
+		return NULL;
 
         for (int i = 0; i < m; i++) {
                 double d = evalute(n, &(x[i * n]), w, b) - y[i];

--- a/ml.h
+++ b/ml.h
@@ -35,7 +35,7 @@ inline double evalute(int n, double *x, double *w, double b);
 
 double cost(size_t n, size_t m, double *x, double *w, double b, double *y);
 
-struct Gradient *compute_gradient(size_t n, size_t m, double *x, double *y, double *w, double b);
+struct Gradient *compute_gradient(size_t n, size_t m, double *x, double *y, double *w, double b, struct Gradient *gradient);
 
 struct Model *gradient_descent(size_t n, size_t m, double *x, double *y, double w_initial,
                 double b_initial, double learning_rate, size_t max_iterations);


### PR DESCRIPTION
better idea would be to allocate and free within descent algorithm